### PR TITLE
develop

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -93,6 +93,8 @@ module.exports = {
     'no-inline-comments': 'off',
     // https://eslint.org/docs/v8.x/rules/no-ternary
     'no-ternary': 'off',
+    // https://eslint.org/docs/latest/rules/no-underscore-dangle
+    'no-underscore-dangle': ['error', { allow: ['__dirname'] }],
     // https://eslint.org/docs/v8.x/rules/one-var
     'one-var': 'off',
   },

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -71,6 +71,8 @@ module.exports = {
 
   parserOptions: {
     // https://eslint.org/docs/v8.x/use/configure/language-options#specifying-parser-options
+    ecmaVersion: 2024,
+    // https://eslint.org/docs/v8.x/use/configure/language-options#specifying-parser-options
     sourceType: 'module',
   },
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Debian 12
-FROM debian:bookworm-20240926
+# Debian 12.8
+FROM debian:bookworm-20241111
 
 ARG user_name=developer
 ARG user_id

--- a/examples/dirname.mjs
+++ b/examples/dirname.mjs
@@ -1,0 +1,3 @@
+const __dirname = import.meta.dirname;
+
+console.log(__dirname);


### PR DESCRIPTION
- **Update vitest monorepo to v2.1.5**
  

- **Update @vitest/eslint-plugin to version 1.1.12 in package.json and package-lock.json**
  

- **Refactor vitest.workspace.js for improved consistency and clarity**
  

- **Add comments**
  

- **npx install-peerdeps --dev eslint-config-airbnb-base**
  

- **Update ESLint configuration to use v8 and extend airbnb-base rules**
  

- **Enhance VSCode settings for improved editing experience and ESLint integration**
  

- **ESLint support**
  

- **Fix import/no-extraneous-dependencies**
  

- **fix: Unable to resolve path to module 'vitest/config'**
  

- **ESLint support**
  

- **feat: add support for @jest/globals in ESLint configuration and package dependencies**
  

- **ESLint support**
  

- **fix: remove unnecessary Jest globals from ESLint configuration**
  

- **fix: disable 'jest/require-hook' rule in ESLint configuration**
  

- **test: add beforeEach test for id validation**
  

- **chore: update parserOptions to support ECMAScript 2024**
  

- **fix: add 'no-underscore-dangle' rule to ESLint configuration**
  

- **feat: add example for using __dirname with import.meta**
  

- **chore: update Dockerfile to use Debian 12.8 image**
  