### PR TITLE
develop

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,11 @@
 {
   "recommendations": [
     //
+    // JSON
+    //
+    // https://marketplace.visualstudio.com/items?itemName=remcohaszing.schemastore
+    "remcohaszing.schemastore",
+    //
     // JavaScript
     //
     // https://marketplace.visualstudio.com/items?itemName=Orta.vscode-jest

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,6 +6,11 @@
     // https://marketplace.visualstudio.com/items?itemName=remcohaszing.schemastore
     "remcohaszing.schemastore",
     //
+    // YAML
+    //
+    // https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml
+    "redhat.vscode-yaml",
+    //
     // JavaScript
     //
     // https://marketplace.visualstudio.com/items?itemName=Orta.vscode-jest
@@ -21,8 +26,6 @@
     "GitHub.copilot",
     // https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-github-actions
     "GitHub.vscode-github-actions",
-    // https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml
-    "redhat.vscode-yaml",
     // https://marketplace.visualstudio.com/items?itemName=timonwong.shellcheck
     "timonwong.shellcheck",
     // https://marketplace.visualstudio.com/items?itemName=usernamehw.errorlens


### PR DESCRIPTION
- **Update vitest monorepo to v2.1.5**
  

- **Update @vitest/eslint-plugin to version 1.1.12 in package.json and package-lock.json**
  

- **Refactor vitest.workspace.js for improved consistency and clarity**
  

- **Add comments**
  

- **npx install-peerdeps --dev eslint-config-airbnb-base**
  

- **Update ESLint configuration to use v8 and extend airbnb-base rules**
  

- **Enhance VSCode settings for improved editing experience and ESLint integration**
  

- **ESLint support**
  

- **Fix import/no-extraneous-dependencies**
  

- **fix: Unable to resolve path to module 'vitest/config'**
  

- **ESLint support**
  

- **feat: add support for @jest/globals in ESLint configuration and package dependencies**
  

- **ESLint support**
  

- **fix: remove unnecessary Jest globals from ESLint configuration**
  

- **fix: disable 'jest/require-hook' rule in ESLint configuration**
  

- **test: add beforeEach test for id validation**
  

- **chore: update parserOptions to support ECMAScript 2024**
  

- **fix: add 'no-underscore-dangle' rule to ESLint configuration**
  

- **feat: add example for using __dirname with import.meta**
  

- **chore: update Dockerfile to use Debian 12.8 image**
  

- **Limit the scope of @vitest/env**
  

- **chore: remove renovate configuration file**
  

- **feat: add recommendation for Schemastore extension in VSCode**
  

- **Swap lines**
  