### PR TITLE
fix: update import statement in vite.config.mjs to use 'vite' instead…

### DIFF
--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -2,7 +2,7 @@
 // .js, .mjs, .cjs, .ts, .cts, .mts.
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { defineConfig } from 'vitest/config';
+import { defineConfig } from 'vite';
 
 export default defineConfig({
   // test: {


### PR DESCRIPTION
… of 'vitest/config'