### PR TITLE
feat: switch Dockerfile.prod to ESM with multi-stage build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,4 +3,6 @@
 
 # Allow only files needed for Docker build
 !docker-entrypoint.sh
-!src/run-to-completion.cjs
+!package.json
+!package-lock.json
+!src/import-check/import-external-esmodule.js

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,8 +1,8 @@
 # Features of this Dockerfile
 #
+# - Multi-stage build: installs npm dependencies in a build stage, then copies to distroless
 # - Based on Google's distroless image (no shell, no package manager, minimal attack surface)
 # - Runs as nonroot user (UID 65534) by default
-# - No dependencies installed; only copies the application source
 # - The container exits after the script completes (run-to-completion model)
 #
 # Build the Docker image:
@@ -14,17 +14,26 @@
 #   docker container run --rm --name $PROJECT-prod-container $PROJECT-prod-image
 #
 # Expected output:
-#   bar!
-#   foo!
-#   baz!
+#   Hello, ES Module!
 #
 
+# --- Build stage ---
+FROM node:24-bookworm-slim AS build
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev
+
+# --- Runtime stage ---
 # distroless Node.js 24 on Debian 12 (bookworm)
 #   https://github.com/GoogleContainerTools/distroless/tree/main/nodejs
 FROM gcr.io/distroless/nodejs24-debian12:nonroot
 
 WORKDIR /app
 
-COPY src/run-to-completion.cjs src/run-to-completion.cjs
+COPY --from=build /app/node_modules node_modules/
+COPY package.json .
+COPY src/import-check/import-external-esmodule.js src/import-check/import-external-esmodule.js
 
-CMD ["src/run-to-completion.cjs"]
+CMD ["src/import-check/import-external-esmodule.js"]


### PR DESCRIPTION
## Summary
- Dockerfile.prod の実行対象を `src/run-to-completion.cjs` から `src/import-check/import-external-esmodule.js` に変更
- ESM + 外部 npm パッケージ (`@uraitakahito/hello-esmodule`) を扱うためマルチステージビルドを導入
- ビルドステージ (`node:24-bookworm-slim`) で `npm ci --omit=dev` を実行し、distroless ランタイムに `node_modules` をコピー

## Test plan
- [ ] `docker image build -f Dockerfile.prod -t hello-javascript-prod-image .` でビルドが成功すること
- [ ] `docker container run --rm hello-javascript-prod-image` で `Hello, ES Module!` が出力されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)