### PR TITLE
feat: strengthen CI workflows for stricter linting and supply chain security

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -21,5 +21,5 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-review
-          eslint_flags: '.'
-          fail_level: error
+          eslint_flags: '. --max-warnings 0'
+          fail_level: warning

--- a/.github/workflows/safe-chain.yml
+++ b/.github/workflows/safe-chain.yml
@@ -20,4 +20,6 @@ jobs:
           npm i -g @aikidosec/safe-chain
           safe-chain setup-ci
       - name: Install dependencies
+        env:
+          SAFE_CHAIN_MINIMUM_PACKAGE_AGE_HOURS: 5
         run: npm ci


### PR DESCRIPTION
## Summary
- **reviewdog.yml**: `eslint_flags` に `--max-warnings 0` を追加し、`fail_level` を `warning` に変更。warning が1つでもあれば CI を失敗させ、PR コメントとしても報告されるようにする
- **safe-chain.yml**: `SAFE_CHAIN_MINIMUM_PACKAGE_AGE_HOURS: 5` を追加。公開から5時間未満のパッケージをブロックし、サプライチェーン攻撃のリスクを軽減する

## Test plan
- [ ] PR 上で reviewdog / safe-chain / hadolint の CI が正常に動作することを確認
- [ ] warning を含むコードを push した場合に reviewdog が PR コメントを投稿し、CI が失敗することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)