### PR TITLE
develop

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -63,7 +63,7 @@ ARG extra_utils_repository="https://github.com/uraitakahito/extra-utils.git"
 ARG extra_utils_commit="3fb9cf4625cdd57270adc48ddf1b230cf151fdf0"
 # Refer to the following URL for Node.js versions:
 #   https://nodejs.org/en/about/previous-releases
-ARG node_version="24.12.0"
+ARG node_version="24.14.1"
 
 ARG LANG=C.UTF-8
 ENV LANG="$LANG"


### PR DESCRIPTION
- **feat: strengthen CI workflows for stricter linting and supply chain security**
  Make reviewdog report warnings (not just errors) and fail on any ESLint
  warning via --max-warnings 0. Add SAFE_CHAIN_MINIMUM_PACKAGE_AGE_HOURS
  to block packages published less than 5 hours ago.
  
  Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
  

- **fix: update Node.js version to 24.14.1 in Dockerfile.dev**
  