### PR TITLE
feat: introduce NODE_ENV across Docker and CI environments

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -16,7 +16,10 @@ jobs:
         with:
           node-version: '24'
           cache: 'npm'
-      - run: npm ci
+      - name: Install dependencies
+        env:
+          NODE_ENV: development
+        run: npm ci
       - uses: reviewdog/action-eslint@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/safe-chain.yml
+++ b/.github/workflows/safe-chain.yml
@@ -21,5 +21,6 @@ jobs:
           safe-chain setup-ci
       - name: Install dependencies
         env:
+          NODE_ENV: development
           SAFE_CHAIN_MINIMUM_PACKAGE_AGE_HOURS: 5
         run: npm ci

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -69,6 +69,7 @@ ARG LANG=C.UTF-8
 ENV LANG="$LANG"
 ARG TZ=UTC
 ENV TZ="$TZ"
+ENV NODE_ENV=development
 
 #
 # Git

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -22,13 +22,18 @@ FROM node:24-bookworm-slim AS build
 
 WORKDIR /app
 
+ENV NODE_ENV=production
+
 COPY package.json package-lock.json ./
-RUN npm ci --omit=dev
+# NODE_ENV=production ensures npm skips devDependencies automatically.
+RUN npm ci
 
 # --- Runtime stage ---
 # distroless Node.js 24 on Debian 12 (bookworm)
 #   https://github.com/GoogleContainerTools/distroless/tree/main/nodejs
 FROM gcr.io/distroless/nodejs24-debian12:nonroot
+
+ENV NODE_ENV=production
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- Set `NODE_ENV=production` in `Dockerfile.prod` (both build and runtime stages) and remove the now-redundant `--omit=dev` flag from `npm ci`
- Set `NODE_ENV=development` in `Dockerfile.dev` to make the environment intent explicit
- Add `NODE_ENV: development` to CI workflows (`reviewdog.yml`, `safe-chain.yml`) to ensure devDependencies are always installed for linting and security scanning

## Test plan
- [ ] Build production image: `docker image build -f Dockerfile.prod -t test-prod .` and verify `Hello, ES Module!` output
- [ ] Verify `echo $NODE_ENV` returns `development` inside the dev container
- [ ] Confirm reviewdog and safe-chain workflows pass on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)