### PR TITLE
feat: install pnpm 11.1.3 in Dockerfile.dev

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -130,7 +130,7 @@ RUN cd /usr/src && \
 #
 RUN INSTALLYARNUSINGAPT=false \
     NVMVERSION="latest" \
-    PNPM_VERSION="none" \
+    PNPMVERSION="11.1.3" \
     USERNAME=${user_name} \
     VERSION=${node_version} \
         /usr/src/features/src/node/install.sh


### PR DESCRIPTION
- Rename env var: `PNPM_VERSION` → `PNPMVERSION` (the name actually read by `features/src/node/install.sh`)
- Pin pnpm to `11.1.3` (current stable latest)

Note: previously `PNPM_VERSION="none"` was silently ignored, so pnpm was being installed with the script's default `latest`. This change makes the version explicitly controllable.