### PR TITLE
docs: add -m 4G to container run example to avoid VS Code OOM

### DIFF
--- a/Dockerfile.dev.container
+++ b/Dockerfile.dev.container
@@ -46,7 +46,11 @@
 #
 # コンテナを起動する場合（ssh-agent はホストから --ssh で転送。SSH_AUTH_SOCK は自動設定されます）：
 #
-#   container run -d --rm --init --ssh -e GH_TOKEN=$(security find-generic-password -a "$USER" -s development-pat -w) -e TERM=$TERM --volume `pwd`:/app --mount type=volume,source=$PROJECT-zsh-history,target=/zsh-volume --name $PROJECT-container $PROJECT-image
+#   -m でメモリ上限を指定します。container の既定は 1GiB で、Visual Studio Code をアタッチして使うと
+#   拡張ホスト（拡張機能を動かす Node プロセス）が OOM で繰り返し落ちます。まずは 4G を、足りなければ
+#   8G などへ増やしてください（確認: container exec $PROJECT-container cat /sys/fs/cgroup/memory.max）。
+#
+#   container run -d --rm --init --ssh -m 4G -e GH_TOKEN=$(security find-generic-password -a "$USER" -s development-pat -w) -e TERM=$TERM --volume `pwd`:/app --mount type=volume,source=$PROJECT-zsh-history,target=/zsh-volume --name $PROJECT-container $PROJECT-image
 #
 # コンテナにログインする。
 #


### PR DESCRIPTION
## 概要
Apple Container 版の開発コンテナ `Dockerfile.dev.container` で、起動コマンドの例に `-m 4G`（メモリ上限）を追加します。

## 背景 / 課題
Apple Container の既定メモリ上限は **1 GiB**。この状態で Visual Studio Code をアタッチして使うと、コンテナ内のリモート拡張ホスト（拡張機能を動かす Node プロセス）が OOM で繰り返し kill され、**"Remote Extension host terminated unexpectedly"** が表示される。

実機の cgroup v2 で確認（`memory.events` の `oom_kill` が増加）:

```
memory.max    1073741824   # = 1 GiB（ハード上限）
memory.peak   1073774592   # 上限に到達
memory.events ... oom_kill 10
```

## 変更
- 起動例に `-m 4G` を追加（VS Code Server＋拡張ホスト＋tsserver＋ESLint 用のメモリを確保）。
- 既定 1 GiB と OOM の理由、増設方法（足りなければ 8G）、確認コマンドをコメントで明記。

純粋にヘッダコメント（ドキュメント）の変更で、イメージのビルド内容は不変。`Dockerfile.dev.docker`（Docker 版）は既定の挙動が異なるため対象外。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RbRp5x3b4D2x6vhda4zPsX
