### PR TITLE
docs: Dockerfile.dev.container のコメント整理と EXPOSE 3000 削除

### DIFF
--- a/Dockerfile.dev.container
+++ b/Dockerfile.dev.container
@@ -1,4 +1,4 @@
-# この Dockerfile の特徴（Apple Container 版）
+# この Dockerfile の特徴
 #
 # - Apple の container(https://github.com/apple/container) 用の開発コンテナです（Docker/OrbStack 版は Dockerfile.dev.docker）
 # - Dev Containers の devcontainer.json 運用は対象外。Visual Studio Code からアタッチして使います
@@ -47,8 +47,7 @@
 # コンテナを起動する場合（ssh-agent はホストから --ssh で転送。SSH_AUTH_SOCK は自動設定されます）：
 #
 #   -m でメモリ上限を指定します。container の既定は 1GiB で、Visual Studio Code をアタッチして使うと
-#   拡張ホスト（拡張機能を動かす Node プロセス）が OOM で繰り返し落ちます。まずは 4G を、足りなければ
-#   8G などへ増やしてください（確認: container exec $PROJECT-container cat /sys/fs/cgroup/memory.max）。
+#   拡張ホスト（拡張機能を動かす Node プロセス）が OOM で繰り返し落ちます。
 #
 #   container run -d --rm --init --ssh -m 4G -e GH_TOKEN=$(security find-generic-password -a "$USER" -s development-pat -w) -e TERM=$TERM --volume `pwd`:/app --mount type=volume,source=$PROJECT-zsh-history,target=/zsh-volume --name $PROJECT-container $PROJECT-image
 #
@@ -56,16 +55,13 @@
 #
 #   container exec -it $PROJECT-container /bin/zsh
 #
-#   または
+# または
 #
 # Visual Studio Code から接続する（拡張設定 "dev.containers.experimentalAppleContainerSupport": true が必要）：
 #
 # 1. **コマンドパレット (Shift + Command + p)** を開く
-# 2. **Dev Containers: Attach to Running Container** を選択する
+# 2. **Dev Containers: Attach to Running Apple Container** を選択する
 # 3. `/app` ディレクトリを開く
-#
-# 詳細：
-#   https://github.com/microsoft/vscode-remote-release/issues/11012
 #
 # （初回のみ）コマンド履歴フォルダの所有者を変更します：
 #

--- a/Dockerfile.dev.container
+++ b/Dockerfile.dev.container
@@ -184,9 +184,6 @@ RUN cd /home/${user_name} && \
     git checkout ${dotfiles_commit} && \
     ./install.sh
 
-# express サーバー
-EXPOSE 3000
-
 WORKDIR /app
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["tail", "-F", "/dev/null"]

--- a/Dockerfile.dev.container
+++ b/Dockerfile.dev.container
@@ -109,7 +109,7 @@ RUN apt-get update -qq && \
 #
 # 開発用ユーザーを作成します。
 #   UID/GID はホストに合わせます。衝突する GID は再利用します（macOS の staff 20 == Debian の dialout）。
-#   ※ Docker 版の ADDUSERTOROOTGROUP は不要（container の --ssh ソケットは srw-rw-rw-=world rw のため）。
+#   container の --ssh ソケットは srw-rw-rw-=world rw です。
 #
 RUN cd /usr/src && \
     git clone ${dev_user_repository} && \


### PR DESCRIPTION
## 概要

`Dockerfile.dev.container`（Apple `container` 版の開発用 Dockerfile）の細かな整理です。コメントの見直しと、不要な `EXPOSE 3000` の削除を行いました。ビルドに関わる `FROM`/`ARG`/`RUN` などのロジックに変更はありません。

## 変更内容

- **docs**: ヘッダー見出しから冗長な「（Apple Container 版）」を削除
- **docs**: メモリ上限（`-m`）の補足説明を簡潔化
- **docs**: VS Code のアタッチ項目を「Attach to Running Apple Container」に修正
- **docs**: 不要な参考 issue リンクを削除
- **docs**: ssh ソケットのコメントを Docker 版との対比表現からやめ、container 単体で意味が通る説明に変更
- **refactor**: 末尾の `EXPOSE 3000`（express ポート公開）を削除

## コミット

- `9e19c4a` docs: refine Dockerfile.dev.container header comments
- `2f84eda` docs: simplify ssh-socket comment in Dockerfile.dev.container
- `23f6377` refactor: drop EXPOSE 3000 from Dockerfile.dev.container

🤖 Generated with [Claude Code](https://claude.com/claude-code)