### PR TITLE
fix: 開発用 Dockerfile のビルドコマンドで PROJECT を小文字化

### DIFF
--- a/Dockerfile.dev.container
+++ b/Dockerfile.dev.container
@@ -12,9 +12,9 @@
 #
 #   container system start
 #
-# イメージをビルドする場合：
+# イメージをビルドする場合（フォルダ名の大文字はイメージ名に使えないため tr で小文字化します）：
 #
-#   PROJECT=$(basename `pwd`) && container build -f Dockerfile.dev.container -t $PROJECT-image . --build-arg TZ=Asia/Tokyo --build-arg user_id=`id -u` --build-arg group_id=`id -g`
+#   PROJECT=$(basename `pwd` | tr '[:upper:]' '[:lower:]') && container build -f Dockerfile.dev.container -t $PROJECT-image . --build-arg TZ=Asia/Tokyo --build-arg user_id=`id -u` --build-arg group_id=`id -g`
 #
 # （初回のみ）コマンド履歴用のボリュームを作成します：
 #

--- a/Dockerfile.dev.docker
+++ b/Dockerfile.dev.docker
@@ -6,9 +6,9 @@
 # - ホスト OS は Mac でのみ動作確認しています
 # - Dockerコンテナ内でGitHubを利用したい場合はfine-grained PATを GH_TOKEN としてコンテナに渡すことを想定しています
 #
-# Docker イメージをビルドする場合：
+# Docker イメージをビルドする場合（フォルダ名の大文字はイメージ名に使えないため tr で小文字化します）：
 #
-#   PROJECT=$(basename `pwd`) && docker image build -f Dockerfile.dev.docker -t $PROJECT-image . --build-arg TZ=Asia/Tokyo --build-arg user_id=`id -u` --build-arg group_id=`id -g`
+#   PROJECT=$(basename `pwd` | tr '[:upper:]' '[:lower:]') && docker image build -f Dockerfile.dev.docker -t $PROJECT-image . --build-arg TZ=Asia/Tokyo --build-arg user_id=`id -u` --build-arg group_id=`id -g`
 #
 # （初回のみ）コマンド履歴用のボリュームを作成します：
 #


### PR DESCRIPTION
## 概要

開発用 Dockerfile（`Dockerfile.dev.container` / `Dockerfile.dev.docker`）のイメージビルドコマンドで、`PROJECT=$(basename `pwd`)` を `tr` で小文字化するよう修正します。

## 背景（実機検証）

フォルダ名に大文字が含まれる場合（例 `Hello-JavaScript`）、`-t $PROJECT-image` のイメージ名が OCI のリポジトリ名規則（小文字のみ）に反し、ビルドが失敗します。`container` 1.0.0 で実測した結果は次のとおり：

| 対象 | 大文字名 | 結果 |
|---|---|---|
| イメージ `-t` | `Foo-Bar-image` | ❌ `Error: invalid format for image reference` |
| ボリューム | `Foo-Bar-zsh-history` | ✅ 作成成功 |
| コンテナ `--name` | `Foo-Bar-container` | ✅ 起動成功 |

イメージ名が最初の関門で落ちるため、ビルド自体が通りません（Docker も同じ規則）。

## 変更内容

- `PROJECT=$(basename `pwd` | tr '[:upper:]' '[:lower:]')` に変更（両 Dockerfile）
- 見出しに理由を一言追記

`PROJECT` を一度小文字化すれば、後続の `volume create` / `run` / `--name` も同じ `$PROJECT` を参照するため、すべて小文字で一貫します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)