### PR TITLE
docs: bump example container memory from 4G to 8G

### DIFF
--- a/Dockerfile.dev.container
+++ b/Dockerfile.dev.container
@@ -49,7 +49,7 @@
 #   -m でメモリ上限を指定します。container の既定は 1GiB で、Visual Studio Code をアタッチして使うと
 #   拡張ホスト（拡張機能を動かす Node プロセス）が OOM で繰り返し落ちます。
 #
-#   container run -d --rm --init --ssh -m 4G -e GH_TOKEN=$(security find-generic-password -a "$USER" -s development-pat -w) -e TERM=$TERM --volume `pwd`:/app --mount type=volume,source=$PROJECT-zsh-history,target=/zsh-volume --name $PROJECT-container $PROJECT-image
+#   container run -d --rm --init --ssh -m 8G -e GH_TOKEN=$(security find-generic-password -a "$USER" -s development-pat -w) -e TERM=$TERM --volume `pwd`:/app --mount type=volume,source=$PROJECT-zsh-history,target=/zsh-volume --name $PROJECT-container $PROJECT-image
 #
 # コンテナにログインする。
 #


### PR DESCRIPTION
## 概要

`Dockerfile.dev.container` のコンテナ起動例コマンドのメモリ上限を `-m 4G` から `-m 8G` に引き上げます。

## 背景

直上のコメントにある通り、Apple `container` の既定メモリは 1GiB で、Visual Studio Code をアタッチして使うと拡張ホスト (拡張機能を動かす Node プロセス) が OOM で繰り返し落ちます。例コマンドの値を実用的な `8G` に更新します。

## 変更内容

- `Dockerfile.dev.container`: 起動例コマンド `-m 4G` → `-m 8G` (コメントブロック内の例、+1/−1)

## 影響範囲

- ドキュメント (Dockerfile 内コメントの例コマンド) のみ。ビルド・実行のロジックには影響しません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)