### PR TITLE
docs: add --dns to build/run examples in Dockerfile.dev.container

### DIFF
--- a/Dockerfile.dev.container
+++ b/Dockerfile.dev.container
@@ -14,7 +14,10 @@
 #
 # イメージをビルドする場合（フォルダ名の大文字はイメージ名に使えないため tr で小文字化します）：
 #
-#   PROJECT=$(basename `pwd` | tr '[:upper:]' '[:lower:]') && container build -f Dockerfile.dev.container -t $PROJECT-image . --build-arg TZ=Asia/Tokyo --build-arg user_id=`id -u` --build-arg group_id=`id -g`
+#   --dns で DNS サーバーを明示します（1.1.1.1=Cloudflare / 8.8.8.8=Google）。
+#   既定では名前解決ができず apt-get / git clone / Node ダウンロードが失敗する環境向けの保険です。
+#
+#   PROJECT=$(basename `pwd` | tr '[:upper:]' '[:lower:]') && container build -f Dockerfile.dev.container -t $PROJECT-image . --dns 1.1.1.1 --dns 8.8.8.8 --build-arg TZ=Asia/Tokyo --build-arg user_id=`id -u` --build-arg group_id=`id -g`
 #
 # （初回のみ）コマンド履歴用のボリュームを作成します：
 #
@@ -49,7 +52,7 @@
 #   -m でメモリ上限を指定します。container の既定は 1GiB で、Visual Studio Code をアタッチして使うと
 #   拡張ホスト（拡張機能を動かす Node プロセス）が OOM で繰り返し落ちます。
 #
-#   container run -d --rm --init --ssh -m 8G -e GH_TOKEN=$(security find-generic-password -a "$USER" -s development-pat -w) -e TERM=$TERM --volume `pwd`:/app --mount type=volume,source=$PROJECT-zsh-history,target=/zsh-volume --name $PROJECT-container $PROJECT-image
+#   container run -d --rm --init --ssh -m 8G --dns 1.1.1.1 --dns 8.8.8.8 -e GH_TOKEN=$(security find-generic-password -a "$USER" -s development-pat -w) -e TERM=$TERM --volume `pwd`:/app --mount type=volume,source=$PROJECT-zsh-history,target=/zsh-volume --name $PROJECT-container $PROJECT-image
 #
 # コンテナにログインする。
 #


### PR DESCRIPTION
## 概要

`Dockerfile.dev.container` のコメント内の例コマンド（ビルド／起動）に `--dns 1.1.1.1 --dns 8.8.8.8` を追記します。名前解決ができない環境で、外部への接続が失敗するのを避けるためです（1.1.1.1=Cloudflare / 8.8.8.8=Google）。

## 背景・検証

Apple `container` 1.0.0 で実機検証した結果、`run` と `build` で `--dns` の効き方が異なることを確認しました。

| | `container run --dns` | `container build --dns` |
|---|---|---|
| コンテナ内 `/etc/resolv.conf` | 指定IPがそのまま入る（`1.1.1.1`/`8.8.8.8`） | 常に `192.168.64.1`（ビルダー VM のゲートウェイ resolver）。`--dns` を渡しても変化せず |
| 効果 | ✅ 直接的・検証済み | ⚠️ ビルダー VM 経由のため間接的（保険として記載） |

- `run`: `--dns` がコンテナの resolv.conf を直接設定するため、確実に効きます。
- `build`: フラグは存在し受理されますが、ビルドはビルダー VM 内で走り、コンテナの resolv.conf はビルダーのゲートウェイを指します。1.0.0 では resolv.conf を書き換えませんでしたが、ビルダー上流の設定として効く可能性があり、無害なため記載しています。

## 変更内容

- `Dockerfile.dev.container`: ビルド／起動の例コマンドに `--dns 1.1.1.1 --dns 8.8.8.8` を追記。ビルド側には簡単な説明コメントを追加（+5/−2、コメントのみ）。

## 影響範囲

- ドキュメント（Dockerfile 内コメントの例コマンド）のみ。ビルド・実行のロジックには影響しません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)