### PR TITLE
feat: persist Claude Code sessions via CLAUDE_CONFIG_DIR for --resume

### DIFF
--- a/Dockerfile.dev.container
+++ b/Dockerfile.dev.container
@@ -27,6 +27,11 @@
 #
 #   container volume create $PROJECT-zsh-history
 #
+# （初回のみ）Claude Code のセッション・設定の保存先ボリュームを作成します：
+# これにより、コンテナを --rm で使い捨てても `claude --resume` で会話を再開できます。
+#
+#   container volume create $PROJECT-claude
+#
 # ── なぜ認証に「fine-grained PAT」を使うのか（他方式の難点）──
 #
 # 前提：gh は GitHub API(HTTPS) を叩くため、認証にトークンが必須です（SSH 鍵では API 認証はできない）。
@@ -51,8 +56,10 @@
 #
 #   -m でメモリ上限を指定します。container の既定は 1GiB で、Visual Studio Code をアタッチして使うと
 #   拡張ホスト（拡張機能を動かす Node プロセス）が OOM で繰り返し落ちます。
+#   --mount の /claude-config は Claude Code のセッション保存先（ENV CLAUDE_CONFIG_DIR）を
+#   永続化し、コンテナを --rm で破棄しても claude --resume を使えるようにします。
 #
-#   container run -d --rm --init --ssh -m 8G --dns 1.1.1.1 --dns 8.8.8.8 -e GH_TOKEN=$(security find-generic-password -a "$USER" -s development-pat -w) -e TERM=$TERM --volume `pwd`:/app --mount type=volume,source=$PROJECT-zsh-history,target=/zsh-volume --name $PROJECT-container $PROJECT-image
+#   container run -d --rm --init --ssh -m 8G --dns 1.1.1.1 --dns 8.8.8.8 -e GH_TOKEN=$(security find-generic-password -a "$USER" -s development-pat -w) -e TERM=$TERM --volume `pwd`:/app --mount type=volume,source=$PROJECT-zsh-history,target=/zsh-volume --mount type=volume,source=$PROJECT-claude,target=/claude-config --name $PROJECT-container $PROJECT-image
 #
 # コンテナにログインする。
 #
@@ -66,9 +73,10 @@
 # 2. **Dev Containers: Attach to Running Apple Container** を選択する
 # 3. `/app` ディレクトリを開く
 #
-# （初回のみ）コマンド履歴フォルダの所有者を変更します：
+# （初回のみ）マウントしたボリューム（コマンド履歴・Claude 設定）の所有者を変更します：
 #
 #   sudo chown -R $(id -u):$(id -g) /zsh-volume
+#   sudo chown -R $(id -u):$(id -g) /claude-config
 #
 
 # Debian 12.13
@@ -175,6 +183,12 @@ RUN INSTALLYARNUSINGAPT=false \
         /usr/src/features/src/node/install.sh
 
 COPY docker-entrypoint.sh /usr/local/bin/
+
+# Claude Code のセッション・設定の保存先（永続ボリュームのマウント先）。
+# 起動コマンドで同名ボリュームをここにマウントすると `claude --resume` が使えるようになる。
+# developer が書けるよう、root のうちに作成して所有者を渡しておく。
+RUN mkdir -p /claude-config && chown ${user_id}:${group_id} /claude-config
+ENV CLAUDE_CONFIG_DIR=/claude-config
 
 USER ${user_name}
 


### PR DESCRIPTION
## 概要

Apple container 版開発コンテナ（`Dockerfile.dev.container`）で、コンテナを `--rm` で使い捨てても `claude --resume` で会話を再開できるようにします。Claude Code のセッション・設定の保存先を、環境変数 `CLAUDE_CONFIG_DIR` で専用の永続ボリュームへ逃がす方式です。

## 背景

現状は `--rm` によりコンテナ終了＝削除のため、セッション実体（`~/.claude/projects/-app/*.jsonl`）が書き込みレイヤーごと消え、`--resume` で再開できませんでした。保存先を永続ボリュームに置くことで解決します。

## 変更内容（`Dockerfile.dev.container` のみ）

- **ENV 焼き込み**: `ENV CLAUDE_CONFIG_DIR=/claude-config` をイメージに固定（`run` で `-e` を付け忘れて無言で揮発する事故を防止）
- **保存先の用意**: `/claude-config` を root のうちに作成し、`${user_id}:${group_id}`（数値）で所有権を付与
- **起動例**: `--mount type=volume,source=$PROJECT-claude,target=/claude-config` を追記
- **初回手順**: ボリューム作成（`container volume create $PROJECT-claude`）と `chown` 手順をコメントに追記

## 検証（実機 / container 1.0.0）

- コンテナ A でセッション相当ファイルを書込 → `container stop`（`--rm` で削除）→ 別コンテナ B を同じボリュームで起動 → **B から参照可能**を確認（受け入れ条件クリア）。
- 新規ボリュームは `root:root` でマウントされるため、**初回 `chown` が必須**であることを確認（コメントに明記済み）。
- `chown` の所有権はボリュームに残るため、2回目以降は不要。
- 数値 `${user_id}:${group_id}` を採用（`developer`/`dialout` は GID 20 共有の別名のため結果は同一だが、名前解決に依存せず堅牢・既存の数値 chown 慣習と一致）。

## 影響範囲

- `Dockerfile.dev.container` の ENV/RUN 追加とコメント追記のみ。`--mount` を付けない起動でも従来どおり動作（保存先が揮発するだけ）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)