### PR TITLE
refactor: symmetric volume mount-point prep + clarify build-time chown shadowing

### DIFF
--- a/Dockerfile.dev.container
+++ b/Dockerfile.dev.container
@@ -184,9 +184,17 @@ RUN INSTALLYARNUSINGAPT=false \
 
 COPY docker-entrypoint.sh /usr/local/bin/
 
-# Claude Code のセッション・設定の保存先（永続ボリュームのマウント先）。
-# 起動コマンドで同名ボリュームをここにマウントすると `claude --resume` が使えるようになる。
-# ボリュームをマウントすると意味はないが、developer が書けるよう、root のうちに作成して所有者を渡して保険をかけておく。
+#
+# zshの履歴の保存先。
+#   ボリュームをマウントすると意味はないが、マウント失敗時の保険をかけておく。
+#
+RUN mkdir -p /zsh-volume && chown ${user_id}:${group_id} /zsh-volume
+
+#
+# Claude Code のセッション・設定の保存先
+#   起動コマンドで同名ボリュームをここにマウントすると `claude --resume` が使えるようになる。
+#   ボリュームをマウントすると意味はないが、マウント失敗時の保険をかけておく。
+#
 RUN mkdir -p /claude-config && chown ${user_id}:${group_id} /claude-config
 ENV CLAUDE_CONFIG_DIR=/claude-config
 

--- a/Dockerfile.dev.container
+++ b/Dockerfile.dev.container
@@ -186,7 +186,7 @@ COPY docker-entrypoint.sh /usr/local/bin/
 
 # Claude Code のセッション・設定の保存先（永続ボリュームのマウント先）。
 # 起動コマンドで同名ボリュームをここにマウントすると `claude --resume` が使えるようになる。
-# developer が書けるよう、root のうちに作成して所有者を渡しておく。
+# ボリュームをマウントすると意味はないが、developer が書けるよう、root のうちに作成して所有者を渡して保険をかけておく。
 RUN mkdir -p /claude-config && chown ${user_id}:${group_id} /claude-config
 ENV CLAUDE_CONFIG_DIR=/claude-config
 


### PR DESCRIPTION
## 概要

`Dockerfile.dev.container` の永続ボリューム用マウントポイント（`/zsh-volume`・`/claude-config`）の build 時準備を対称に整理し、build 時 `chown` の効き方をコメントで明確化します。

## 背景

調査により、build 時の `mkdir + chown /claude-config` は **ボリュームをマウントすると覆い隠されて無効**（実体はボリュームのルート＝`root:root`）であることが判明しました。効くのは「ボリュームを `--mount` しない／マウントに失敗した」退化ケースのみです。

## 変更内容（`Dockerfile.dev.container` のみ、コメント＋ビルドステップ）

- **`d0135cb` docs**: build 時 `chown /claude-config` はボリュームマウント時に無効である旨をコメントに明記。
- **`b8d0eb8` refactor**: `/zsh-volume` も `/claude-config` と同様に build 時 `mkdir + chown` で developer 所有で用意し、両マウントポイントを対称に揃える。いずれも「マウントしない/失敗した場合の保険」という位置づけをコメントで統一。

## 補足

- ボリュームを正しく `--mount` した通常運用では、所有権は起動後の手動 `sudo chown`（初回手順）で揃える点は従来どおり。build 時の準備はあくまで保険。
- ロジックへの影響なし（mkdir/chown の追加とコメントのみ）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)