### PR TITLE
docs: improve GH_TOKEN examples in dev Dockerfiles

### DIFF
--- a/Dockerfile.dev.container
+++ b/Dockerfile.dev.container
@@ -48,7 +48,7 @@
 # （初回のみ）fine-grained PAT を macOS Keychain に保存します（以下で GH_TOKEN として使用）：
 #
 # fine-grained PAT を https://github.com/settings/personal-access-tokens/new で作成し
-#   security add-generic-password -a "$USER" -s m4-development -w
+#   security add-generic-password -a "$USER" -s YOUR-FINE-GRAINED-PAT -w
 #   （-w に値を付けないと安全に入力でき、PAT がシェル履歴に残らない。
 #    後でローテーションするときは同じコマンドを -U 付きで再実行して上書きします。）
 #
@@ -59,7 +59,11 @@
 #   --mount の /claude-config は Claude Code のセッション保存先（ENV CLAUDE_CONFIG_DIR）を
 #   永続化し、コンテナを --rm で破棄しても claude --resume を使えるようにします。
 #
-#   container run -d --rm --init --ssh -m 8G --dns 1.1.1.1 --dns 8.8.8.8 -e GH_TOKEN=$(security find-generic-password -a "$USER" -s m4-development -w) -e TERM=$TERM --volume `pwd`:/app --mount type=volume,source=$PROJECT-zsh-history,target=/zsh-volume --mount type=volume,source=$PROJECT-claude,target=/claude-config --name $PROJECT-container $PROJECT-image
+#   container run -d --rm --init --ssh -m 8G --dns 1.1.1.1 --dns 8.8.8.8 -e GH_TOKEN=$(gh auth token) -e TERM=$TERM --volume `pwd`:/app --mount type=volume,source=$PROJECT-zsh-history,target=/zsh-volume --mount type=volume,source=$PROJECT-claude,target=/claude-config --name $PROJECT-container $PROJECT-image
+#
+# もしくは
+#
+#   container run -d --rm --init --ssh -m 8G --dns 1.1.1.1 --dns 8.8.8.8 -e GH_TOKEN=$(security find-generic-password -a "$USER" -s YOUR-FINE-GRAINED-PAT -w) -e TERM=$TERM --volume `pwd`:/app --mount type=volume,source=$PROJECT-zsh-history,target=/zsh-volume --mount type=volume,source=$PROJECT-claude,target=/claude-config --name $PROJECT-container $PROJECT-image
 #
 # コンテナにログインする。
 #

--- a/Dockerfile.dev.container
+++ b/Dockerfile.dev.container
@@ -48,7 +48,7 @@
 # （初回のみ）fine-grained PAT を macOS Keychain に保存します（以下で GH_TOKEN として使用）：
 #
 # fine-grained PAT を https://github.com/settings/personal-access-tokens/new で作成し
-#   security add-generic-password -a "$USER" -s development-pat -w
+#   security add-generic-password -a "$USER" -s m4-development -w
 #   （-w に値を付けないと安全に入力でき、PAT がシェル履歴に残らない。
 #    後でローテーションするときは同じコマンドを -U 付きで再実行して上書きします。）
 #
@@ -59,7 +59,7 @@
 #   --mount の /claude-config は Claude Code のセッション保存先（ENV CLAUDE_CONFIG_DIR）を
 #   永続化し、コンテナを --rm で破棄しても claude --resume を使えるようにします。
 #
-#   container run -d --rm --init --ssh -m 8G --dns 1.1.1.1 --dns 8.8.8.8 -e GH_TOKEN=$(security find-generic-password -a "$USER" -s development-pat -w) -e TERM=$TERM --volume `pwd`:/app --mount type=volume,source=$PROJECT-zsh-history,target=/zsh-volume --mount type=volume,source=$PROJECT-claude,target=/claude-config --name $PROJECT-container $PROJECT-image
+#   container run -d --rm --init --ssh -m 8G --dns 1.1.1.1 --dns 8.8.8.8 -e GH_TOKEN=$(security find-generic-password -a "$USER" -s m4-development -w) -e TERM=$TERM --volume `pwd`:/app --mount type=volume,source=$PROJECT-zsh-history,target=/zsh-volume --mount type=volume,source=$PROJECT-claude,target=/claude-config --name $PROJECT-container $PROJECT-image
 #
 # コンテナにログインする。
 #

--- a/Dockerfile.dev.docker
+++ b/Dockerfile.dev.docker
@@ -34,13 +34,13 @@
 # （初回のみ）fine-grained PAT を macOS Keychain に保存します（以下で GH_TOKEN として使用）：
 #
 # fine-grained PAT を https://github.com/settings/personal-access-tokens/new で作成し
-#   security add-generic-password -a "$USER" -s development-pat -w
+#   security add-generic-password -a "$USER" -s m4-development -w
 #   （-w に値を付けないと安全に入力でき、PAT がシェル履歴に残らない。
 #    後でローテーションするときは同じコマンドを -U 付きで再実行して上書きします。）
 #
 # Docker コンテナを起動する場合（/run/host-services/ssh-auth.sock は Docker Desktop for Mac が提供する仮想ソケット）：
 #
-#   docker container run -d --rm --init -v /run/host-services/ssh-auth.sock:/run/host-services/ssh-auth.sock -e SSH_AUTH_SOCK=/run/host-services/ssh-auth.sock -e GH_TOKEN=$(security find-generic-password -a "$USER" -s development-pat -w) -e TERM=$TERM --mount type=bind,src=`pwd`,dst=/app --mount type=volume,source=$PROJECT-zsh-history,target=/zsh-volume --name $PROJECT-container $PROJECT-image
+#   docker container run -d --rm --init -v /run/host-services/ssh-auth.sock:/run/host-services/ssh-auth.sock -e SSH_AUTH_SOCK=/run/host-services/ssh-auth.sock -e GH_TOKEN=$(security find-generic-password -a "$USER" -s m4-development -w) -e TERM=$TERM --mount type=bind,src=`pwd`,dst=/app --mount type=volume,source=$PROJECT-zsh-history,target=/zsh-volume --name $PROJECT-container $PROJECT-image
 #
 # コンテナにログインする。
 #

--- a/Dockerfile.dev.docker
+++ b/Dockerfile.dev.docker
@@ -34,13 +34,13 @@
 # （初回のみ）fine-grained PAT を macOS Keychain に保存します（以下で GH_TOKEN として使用）：
 #
 # fine-grained PAT を https://github.com/settings/personal-access-tokens/new で作成し
-#   security add-generic-password -a "$USER" -s m4-development -w
+#   security add-generic-password -a "$USER" -s YOUR-FINE-GRAINED-PAT -w
 #   （-w に値を付けないと安全に入力でき、PAT がシェル履歴に残らない。
 #    後でローテーションするときは同じコマンドを -U 付きで再実行して上書きします。）
 #
 # Docker コンテナを起動する場合（/run/host-services/ssh-auth.sock は Docker Desktop for Mac が提供する仮想ソケット）：
 #
-#   docker container run -d --rm --init -v /run/host-services/ssh-auth.sock:/run/host-services/ssh-auth.sock -e SSH_AUTH_SOCK=/run/host-services/ssh-auth.sock -e GH_TOKEN=$(security find-generic-password -a "$USER" -s m4-development -w) -e TERM=$TERM --mount type=bind,src=`pwd`,dst=/app --mount type=volume,source=$PROJECT-zsh-history,target=/zsh-volume --name $PROJECT-container $PROJECT-image
+#   docker container run -d --rm --init -v /run/host-services/ssh-auth.sock:/run/host-services/ssh-auth.sock -e SSH_AUTH_SOCK=/run/host-services/ssh-auth.sock -e GH_TOKEN=$(security find-generic-password -a "$USER" -s YOUR-FINE-GRAINED-PAT -w) -e TERM=$TERM --mount type=bind,src=`pwd`,dst=/app --mount type=volume,source=$PROJECT-zsh-history,target=/zsh-volume --name $PROJECT-container $PROJECT-image
 #
 # コンテナにログインする。
 #


### PR DESCRIPTION
## What

Improve the `GH_TOKEN` setup examples in the dev container Dockerfiles (comment/documentation only).

- Replace the Keychain item name in the examples with a `YOUR-FINE-GRAINED-PAT` placeholder, so the committed template is not tied to one machine's Keychain entry.
- Add `gh auth token` as the primary `GH_TOKEN` source in `Dockerfile.dev.container`, keeping the `security find-generic-password` (Keychain) lookup as an alternative.

## Why

Makes the run examples copy-paste friendly for any environment and offers a simpler token source (`gh auth token`) alongside the Keychain approach.

## Scope

- `Dockerfile.dev.container`
- `Dockerfile.dev.docker`

Comment-only — no build-stage or runtime behavior changes.

## Commits

- `39cc342` rename Keychain item example name
- `ec4b933` switch to placeholder + add `gh auth token` option

🤖 Generated with [Claude Code](https://claude.com/claude-code)