### PR TITLE
feat: serve docs via Nginx (extra-utils 1.6.0 ADDNGINX, runtime-switchable root)

### DIFF
--- a/Dockerfile.dev.container
+++ b/Dockerfile.dev.container
@@ -81,6 +81,19 @@
 #
 #   sudo chown -R $(id -u):$(id -g) /zsh-volume /claude-config
 #
+# コンテナ内のドキュメントを Nginx 越しに閲覧する（extra-utils の ADDNGINX で導入済み）：
+#
+# 配信ルートは /srv/docs（symlink）に固定。起動時に docs-root で配信先を選べます（既定 /app）。
+#
+#   sudo nginx                                     # 起動（既定 root = /app）
+#   sudo docs-root /app/private-note/tmp           # 配信先を切替（symlink を張替）
+#   sudo nginx -s reload  /  sudo nginx -s stop    # 再読込 / 停止
+#
+# ホストからは Apple container の固有 IP で開きます：
+#
+#   container ls                                   # ADDRESS を確認（例 192.168.64.3）
+#   open http://<ADDRESS>:8080/
+#
 
 # Debian 12.13
 FROM docker.io/library/debian:bookworm-20260610
@@ -94,9 +107,9 @@ ARG dev_user_commit="894e51b5cf42983af6c9e393ce93e163c365c9fe"
 # 本家の devcontainers/features
 ARG features_repository="https://github.com/devcontainers/features.git"
 ARG features_commit="a8f0b45732c6b170aa48d9276c01da13be9d6e71"
-# https://github.com/uraitakahito/extra-utils/releases/tag/1.3.0
+# https://github.com/uraitakahito/extra-utils/releases/tag/1.6.0
 ARG extra_utils_repository="https://github.com/uraitakahito/extra-utils.git"
-ARG extra_utils_commit="f975dbcb18f44b518cc181cedad57fd790d9894a"
+ARG extra_utils_commit="1c6016daf3b28a89014401124d2aa5178a5df5e8"
 # https://github.com/uraitakahito/dotfiles/releases/tag/1.1.13
 ARG dotfiles_repository="https://github.com/uraitakahito/dotfiles.git"
 ARG dotfiles_commit="48494bb371b4ffcba85156210a65742e1d8e30ee"
@@ -166,6 +179,7 @@ RUN cd /usr/src && \
     ADDEZA=true \
     ADDGRPCURL=true \
     ADDHADOLINT=true \
+    ADDNGINX=true \
     \
     ADDCLAUDECODE=true \
     # Claude Code は $HOME 配下にインストールされるため、ユーザー名の指定が必要。


### PR DESCRIPTION
## Summary

Enables Nginx-based doc viewing in the dev container by adopting **extra-utils 1.6.0** (`ADDNGINX`). The served root is the `/srv/docs` symlink; `sudo docs-root <DIR>` repoints it, so the directory is chosen when nginx is started manually (`sudo nginx`) — no rebuild needed.

## Changes (`Dockerfile.dev.container`)

- Pin extra-utils `1.3.0` → `1.6.0` (`1c6016d`)
- Add `ADDNGINX=true` to the extra-utils install (`USERNAME` is already passed → nginx workers run as the dev user)
- Add Nginx usage notes (manual `sudo nginx`, `docs-root`, host access via `container ls` IP)

## Verification (end-to-end, Apple container)

Built the full image and ran it:

- build-time `nginx -t` successful; `Nginx ready: root=/srv/docs -> /app on :8080 (worker=developer)`
- runtime: `sudo nginx` starts (master root / workers developer), `curl :8080` → HTTP 200 reading the bind-mounted `/app` (no 403)
- `sudo docs-root /app/sub` switches the served root at runtime; nonexistent dir rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
