### PR TITLE
container: re-seed Claude config in entrypoint after volume mount

### DIFF
--- a/Dockerfile.dev.container
+++ b/Dockerfile.dev.container
@@ -110,9 +110,9 @@ ARG features_commit="a8f0b45732c6b170aa48d9276c01da13be9d6e71"
 # https://github.com/uraitakahito/extra-utils/releases/tag/1.6.0
 ARG extra_utils_repository="https://github.com/uraitakahito/extra-utils.git"
 ARG extra_utils_commit="1c6016daf3b28a89014401124d2aa5178a5df5e8"
-# https://github.com/uraitakahito/dotfiles/releases/tag/1.1.13
+# https://github.com/uraitakahito/dotfiles/releases/tag/1.1.14
 ARG dotfiles_repository="https://github.com/uraitakahito/dotfiles.git"
-ARG dotfiles_commit="48494bb371b4ffcba85156210a65742e1d8e30ee"
+ARG dotfiles_commit="9bd20d5b8436e914f57f6d4627a93efea6afab3f"
 # Node.js のバージョンは次の URL を参照：
 #   https://nodejs.org/en/about/previous-releases
 ARG node_version="24.14.1"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -10,7 +10,27 @@ _is_sourced() {
 		&& [ "${FUNCNAME[1]}" = 'source' ]
 }
 
+# Re-seed Claude Code config after the volume is mounted.
+#
+# This image mounts a named volume over $CLAUDE_CONFIG_DIR (=/claude-config)
+# at runtime (so `claude --resume` survives `--rm`). That mount shadows the
+# symlinks dotfiles' install.sh created at build time, leaving the custom
+# statusLine / hooks hidden. The entrypoint runs *after* the mount, so
+# re-creating the symlinks here makes them stick.
+#
+# No-op when CLAUDE_CONFIG_DIR is unset (e.g. the plain Docker image). Never
+# fatal: a failure here must not take down the container (we run under set -e).
+_seed_claude_config() {
+	[ -n "${CLAUDE_CONFIG_DIR:-}" ] || return 0
+	local seeder="$HOME/dotfiles/config/claude-code/seed-config-dir.sh"
+	[ -x "$seeder" ] || { echo "entrypoint: seeder not found, skipping" >&2; return 0; }
+	# A freshly created volume can be root-owned; take ownership (passwordless sudo).
+	sudo -n chown -R "$(id -u):$(id -g)" "$CLAUDE_CONFIG_DIR" 2>/dev/null || true
+	"$seeder" || echo "entrypoint: seed-config-dir.sh failed (non-fatal)" >&2
+}
+
 _main() {
+    _seed_claude_config
     exec "$@"
 }
 


### PR DESCRIPTION
## What

Re-seed Claude Code config in `docker-entrypoint.sh` after the volume is
mounted, and bump the pinned dotfiles to 1.1.14 (which adds the seeder).

## Why

The Apple `container` image mounts a named volume over `$CLAUDE_CONFIG_DIR`
(`/claude-config`) at runtime so `claude --resume` survives `--rm`. That
mount shadows the symlinks dotfiles' install.sh created at build time,
hiding the custom statusLine / hooks — the container fell back to the
default status line.

The entrypoint runs *after* the mount, so it now re-runs dotfiles'
`seed-config-dir.sh` to re-create the symlinks on the volume. No-op when
`CLAUDE_CONFIG_DIR` is unset (the plain Docker image), non-fatal on error.

## Verification

Rebuilt `crawler-image` (same template) with a fresh `crawler-claude`
volume and confirmed inside the running container:

- `/claude-config/settings.json` is now a **symlink** to the dotfiles
  276-line file (previously a 90-byte real file without `statusLine`).
- `statusline.sh` is present and runs (`5h --% … 7d --% …`).
- `/claude-config` is still the mounted ext4 volume — proving the
  entrypoint re-seeded *after* the mount.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
