### PR TITLE
container: auto-chown /zsh-volume in entrypoint (_own_mount)

### DIFF
--- a/Dockerfile.dev.container
+++ b/Dockerfile.dev.container
@@ -77,10 +77,8 @@
 # 2. **Dev Containers: Attach to Running Apple Container** を選択する
 # 3. `/app` ディレクトリを開く
 #
-# （初回のみ）マウントした zsh 履歴ボリュームの所有者を変更します
-#   （/claude-config は docker-entrypoint.sh が起動時に自動 chown します）：
-#
-#   sudo chown -R $(id -u):$(id -g) /zsh-volume
+# マウントしたボリューム（zsh 履歴 / Claude 設定）の所有者は、
+# docker-entrypoint.sh が起動時に自動で developer へ chown します（手動操作は不要）。
 #
 # コンテナ内のドキュメントを Nginx 越しに閲覧する（extra-utils の ADDNGINX で導入済み）：
 #

--- a/Dockerfile.dev.docker
+++ b/Dockerfile.dev.docker
@@ -55,9 +55,8 @@
 # 詳細：
 #   https://code.visualstudio.com/docs/devcontainers/attach-container#_attach-to-a-docker-container
 #
-# （初回のみ）コマンド履歴フォルダの所有者を変更します：
-#
-#   sudo chown -R $(id -u):$(id -g) /zsh-volume
+# マウントした zsh 履歴ボリュームの所有者は、docker-entrypoint.sh が
+# 起動時に自動で developer へ chown します（手動操作は不要）。
 #
 
 # Debian 12.13

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -10,6 +10,15 @@ _is_sourced() {
 		&& [ "${FUNCNAME[1]}" = 'source' ]
 }
 
+# Make a runtime-mounted volume writable by the dev user.
+# Freshly created named volumes come up root-owned; chown after the mount.
+# No-op if the path is absent (not mounted). Never fatal (we run under set -e).
+_own_mount() {
+	local d="$1"
+	[ -n "$d" ] && [ -d "$d" ] || return 0
+	sudo -n chown -R "$(id -u):$(id -g)" "$d" 2>/dev/null || true
+}
+
 # Re-seed Claude Code config after the volume is mounted.
 #
 # This image mounts a named volume over $CLAUDE_CONFIG_DIR (=/claude-config)
@@ -24,12 +33,12 @@ _seed_claude_config() {
 	[ -n "${CLAUDE_CONFIG_DIR:-}" ] || return 0
 	local seeder="$HOME/dotfiles/config/claude-code/seed-config-dir.sh"
 	[ -x "$seeder" ] || { echo "entrypoint: seeder not found, skipping" >&2; return 0; }
-	# A freshly created volume can be root-owned; take ownership (passwordless sudo).
-	sudo -n chown -R "$(id -u):$(id -g)" "$CLAUDE_CONFIG_DIR" 2>/dev/null || true
 	"$seeder" || echo "entrypoint: seed-config-dir.sh failed (non-fatal)" >&2
 }
 
 _main() {
+    _own_mount "${CLAUDE_CONFIG_DIR:-}"
+    _own_mount /zsh-volume
     _seed_claude_config
     exec "$@"
 }


### PR DESCRIPTION
## What

Factor the runtime volume-ownership chown into a reusable `_own_mount()` in
`docker-entrypoint.sh` and apply it to both `/claude-config` and `/zsh-volume`.

## Why

Previously the entrypoint auto-chowned only `/claude-config`; `/zsh-volume`
still needed a manual first-time `sudo chown`. Freshly created named volumes
come up root-owned, so a fresh zsh-history volume left the shell unable to
persist history until the user chowned it by hand.

The entrypoint runs after the mount, so chowning both volumes there makes them
writable by the dev user — eliminating the last manual step. The Docker variant
shares the entrypoint and benefits too; comments updated accordingly.

## Verification

Rebuilt `crawler-image` with fresh `crawler-claude` AND `crawler-zsh-history`
volumes (both root-owned at creation):

- `/zsh-volume` ends up `developer`-owned and writable — zsh history persists
  with NO manual `sudo chown` ✓
- `/claude-config` unchanged: `settings.json` symlink + `statusLine` ✓
- both confirmed as mounted ext4 volumes ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)
