### PR TITLE
container: delegate entrypoint setup to dotfiles/container-init.sh

### DIFF
--- a/Dockerfile.dev.container
+++ b/Dockerfile.dev.container
@@ -109,9 +109,9 @@ ARG features_commit="a8f0b45732c6b170aa48d9276c01da13be9d6e71"
 # https://github.com/uraitakahito/extra-utils/releases/tag/1.6.0
 ARG extra_utils_repository="https://github.com/uraitakahito/extra-utils.git"
 ARG extra_utils_commit="1c6016daf3b28a89014401124d2aa5178a5df5e8"
-# https://github.com/uraitakahito/dotfiles/releases/tag/1.1.14
+# https://github.com/uraitakahito/dotfiles/releases/tag/1.1.15
 ARG dotfiles_repository="https://github.com/uraitakahito/dotfiles.git"
-ARG dotfiles_commit="9bd20d5b8436e914f57f6d4627a93efea6afab3f"
+ARG dotfiles_commit="b27d9d287769bf919eaf5a07b34e9b67bfa7b504"
 # Node.js のバージョンは次の URL を参照：
 #   https://nodejs.org/en/about/previous-releases
 ARG node_version="24.14.1"

--- a/Dockerfile.dev.container
+++ b/Dockerfile.dev.container
@@ -84,9 +84,9 @@
 #
 # 配信ルートは /srv/docs（symlink）に固定。起動時に docs-root で配信先を選べます（既定 /app）。
 #
-#   sudo nginx                                     # 起動（既定 root = /app）
-#   sudo docs-root /app/private-note/tmp           # 配信先を切替（symlink を張替）
-#   sudo nginx -s reload  /  sudo nginx -s stop    # 再読込 / 停止
+#   sudo nginx                           # 起動（既定 root = /app）
+#   sudo docs-root /app/private-note/tmp # 配信先を切替（symlink を張替）
+#   sudo nginx -s reload.                # 再読込
 #
 # ホストからは Apple container の固有 IP で開きます：
 #

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -10,36 +10,11 @@ _is_sourced() {
 		&& [ "${FUNCNAME[1]}" = 'source' ]
 }
 
-# 実行時にマウントされたボリュームを開発ユーザーが書き込めるようにする。
-# 新規作成された named volume は root 所有で現れるので、マウント後に chown する。
-# パスが無ければ（未マウントなら）何もしない。set -e 下でも致命的にしない。
-_own_mount() {
-	local d="$1"
-	[ -n "$d" ] && [ -d "$d" ] || return 0
-	sudo -n chown -R "$(id -u):$(id -g)" "$d" 2>/dev/null || true
-}
-
-# ボリュームのマウント後に Claude Code の設定を貼り直す。
-#
-# このイメージは実行時に named volume を $CLAUDE_CONFIG_DIR (=/claude-config) へ
-# 上書きマウントする（これで `claude --resume` が `--rm` でも生き残る）。その
-# マウントは dotfiles の install.sh がビルド時に張った symlink を覆い隠し、独自の
-# statusLine / hooks を見えなくする。entrypoint はマウントの *後* に走るので、
-# ここで symlink を貼り直せば有効なまま残る。
-#
-# CLAUDE_CONFIG_DIR が未設定なら（例：素の Docker イメージ）何もしない。ここでの
-# 失敗でコンテナを落としてはならないので、致命的にしない（set -e 下で動作）。
-_seed_claude_config() {
-	[ -n "${CLAUDE_CONFIG_DIR:-}" ] || return 0
-	local seeder="$HOME/dotfiles/config/claude-code/seed-config-dir.sh"
-	[ -x "$seeder" ] || { echo "entrypoint: seeder not found, skipping" >&2; return 0; }
-	"$seeder" || echo "entrypoint: seed-config-dir.sh failed (non-fatal)" >&2
-}
-
 _main() {
-    _own_mount "${CLAUDE_CONFIG_DIR:-}"
-    _own_mount /zsh-volume
-    _seed_claude_config
+    # コンテナ側の規約セットアップ（ボリューム所有権・Claude 設定など）は
+    # dotfiles に一任する。このテンプレートはツール固有の知識を持たない。
+    local init="$HOME/dotfiles/container-init.sh"
+    [ -x "$init" ] && { "$init" || echo "entrypoint: container-init.sh failed (non-fatal)" >&2; }
     exec "$@"
 }
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 set -eo pipefail
 shopt -s nullglob
 
-# check to see if this file is being run or sourced from another script
+# このファイルが直接実行されたのか、別スクリプトから source されたのかを確認する
 _is_sourced() {
 	# https://unix.stackexchange.com/a/215279
 	[ "${#FUNCNAME[@]}" -ge 2 ] \
@@ -10,25 +10,25 @@ _is_sourced() {
 		&& [ "${FUNCNAME[1]}" = 'source' ]
 }
 
-# Make a runtime-mounted volume writable by the dev user.
-# Freshly created named volumes come up root-owned; chown after the mount.
-# No-op if the path is absent (not mounted). Never fatal (we run under set -e).
+# 実行時にマウントされたボリュームを開発ユーザーが書き込めるようにする。
+# 新規作成された named volume は root 所有で現れるので、マウント後に chown する。
+# パスが無ければ（未マウントなら）何もしない。set -e 下でも致命的にしない。
 _own_mount() {
 	local d="$1"
 	[ -n "$d" ] && [ -d "$d" ] || return 0
 	sudo -n chown -R "$(id -u):$(id -g)" "$d" 2>/dev/null || true
 }
 
-# Re-seed Claude Code config after the volume is mounted.
+# ボリュームのマウント後に Claude Code の設定を貼り直す。
 #
-# This image mounts a named volume over $CLAUDE_CONFIG_DIR (=/claude-config)
-# at runtime (so `claude --resume` survives `--rm`). That mount shadows the
-# symlinks dotfiles' install.sh created at build time, leaving the custom
-# statusLine / hooks hidden. The entrypoint runs *after* the mount, so
-# re-creating the symlinks here makes them stick.
+# このイメージは実行時に named volume を $CLAUDE_CONFIG_DIR (=/claude-config) へ
+# 上書きマウントする（これで `claude --resume` が `--rm` でも生き残る）。その
+# マウントは dotfiles の install.sh がビルド時に張った symlink を覆い隠し、独自の
+# statusLine / hooks を見えなくする。entrypoint はマウントの *後* に走るので、
+# ここで symlink を貼り直せば有効なまま残る。
 #
-# No-op when CLAUDE_CONFIG_DIR is unset (e.g. the plain Docker image). Never
-# fatal: a failure here must not take down the container (we run under set -e).
+# CLAUDE_CONFIG_DIR が未設定なら（例：素の Docker イメージ）何もしない。ここでの
+# 失敗でコンテナを落としてはならないので、致命的にしない（set -e 下で動作）。
 _seed_claude_config() {
 	[ -n "${CLAUDE_CONFIG_DIR:-}" ] || return 0
 	local seeder="$HOME/dotfiles/config/claude-code/seed-config-dir.sh"
@@ -43,7 +43,7 @@ _main() {
     exec "$@"
 }
 
-# If we are sourced from elsewhere, don't perform any further actions
+# 別スクリプトから source された場合は、これ以上何もしない
 if ! _is_sourced; then
 	_main "$@"
 fi


### PR DESCRIPTION
## What

Delegate all container-side setup from `docker-entrypoint.sh` to a single
dotfiles hook, `container-init.sh`, and bump the pinned dotfiles to 1.1.15.

## Why

The entrypoint had accumulated three responsibilities: generic init mechanics,
volume-ownership chown, and Claude config seeding — the latter two carrying
tool-specific knowledge and hardcoded paths.

`container-init.sh` (added in dotfiles 1.1.15) now owns the chown + seed. The
template's entrypoint is reduced to its proper job: run the dotfiles hook
(best-effort), then `exec` the CMD. The convention knowledge lives in dotfiles
— where those conventions are defined — and the template becomes generic and
reusable.

## Verification

Rebuilt `crawler-image` (same template) on dotfiles 1.1.15 with fresh
`crawler-claude` + `crawler-zsh-history` volumes:

- entrypoint no longer contains `_own_mount` / `_seed_claude_config` — only the
  delegation ✓
- `~/dotfiles/container-init.sh` is present in the image ✓
- via the hook: `/claude-config` & `/zsh-volume` end up `developer`-owned,
  `settings.json` is a symlink with `statusLine`, `statusline.sh` runs ✓
- bare run (no `--mount`): non-fatal, the container still starts ✓

This PR also carries two earlier pending commits on develop (Japanese
translation of the entrypoint comments; nginx comment tidy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
