### PR TITLE
feat: adopt extra-utils 1.9.0 and enable ADDUV (uv/uvx for Python MCP servers)

### DIFF
--- a/Dockerfile.dev.container
+++ b/Dockerfile.dev.container
@@ -124,9 +124,9 @@ ARG dev_user_commit="894e51b5cf42983af6c9e393ce93e163c365c9fe"
 # 本家の devcontainers/features
 ARG features_repository="https://github.com/devcontainers/features.git"
 ARG features_commit="a8f0b45732c6b170aa48d9276c01da13be9d6e71"
-# https://github.com/uraitakahito/extra-utils/releases/tag/1.8.0
+# https://github.com/uraitakahito/extra-utils/releases/tag/1.9.0
 ARG extra_utils_repository="https://github.com/uraitakahito/extra-utils.git"
-ARG extra_utils_commit="962275980072819ec45c972989844de929348778"
+ARG extra_utils_commit="2706b43b67604fc8ccdb263ab6ff242ee66694b6"
 # https://github.com/uraitakahito/dotfiles/releases/tag/1.1.15
 ARG dotfiles_repository="https://github.com/uraitakahito/dotfiles.git"
 ARG dotfiles_commit="b27d9d287769bf919eaf5a07b34e9b67bfa7b504"
@@ -199,6 +199,7 @@ RUN cd /usr/src && \
     ADDHADOLINT=true \
     ADDIMAGEMAGICK=true \
     ADDNGINX=true \
+    ADDUV=true \
     \
     ADDCLAUDECODE=true \
     # Claude Code は $HOME 配下にインストールされるため、ユーザー名の指定が必要。


### PR DESCRIPTION
## 概要
コンテナ内の Claude Code から Python 製 MCP サーバー（例: `mcp-google-sheets`）を起動できるよう、`uv`/`uvx` をイメージに導入します。extra-utils 1.9.0 の新フラグ `ADDUV` を使います。

## 変更内容（`Dockerfile.dev.container`）
- `extra_utils_commit` を **1.9.0 のマージコミット** `2706b43…` にピン更新（コメントの tag も 1.8.0→1.9.0）
- extra-utils の RUN ブロックに `ADDUV=true`（アルファベット順で `ADDNGINX` の後）

## 前提（別リポ・完了済み）
- extra-utils #23 をマージし **1.9.0** をリリース済み。`install_uv()` が uv 公式インストーラをバージョン URL でピンして `/usr/local/bin` に `uv`/`uvx` を配置。

## 検証
- hadolint クリーン。旧ピン/旧 tag の残存なし
- ※ uv の実インストールはビルド時 `install_uv` が初実行（リビルドで `uv --version` を確認）

## 次の一歩（この PR の範囲外・共通部品）
- MCP 登録用 `.mcp.json` のコミットと、Google サービスアカウント JSON の ro マウント（`private-note/tmp` の提案ドキュメント参照）

🤖 Generated with [Claude Code](https://claude.com/claude-code)