### PR TITLE
chore: adopt dotfiles 1.1.16 (reserve ~/.config/mcp slot for Claude Code CLI)

### DIFF
--- a/Dockerfile.dev.container
+++ b/Dockerfile.dev.container
@@ -127,9 +127,9 @@ ARG features_commit="a8f0b45732c6b170aa48d9276c01da13be9d6e71"
 # https://github.com/uraitakahito/extra-utils/releases/tag/1.9.0
 ARG extra_utils_repository="https://github.com/uraitakahito/extra-utils.git"
 ARG extra_utils_commit="2706b43b67604fc8ccdb263ab6ff242ee66694b6"
-# https://github.com/uraitakahito/dotfiles/releases/tag/1.1.15
+# https://github.com/uraitakahito/dotfiles/releases/tag/1.1.16
 ARG dotfiles_repository="https://github.com/uraitakahito/dotfiles.git"
-ARG dotfiles_commit="b27d9d287769bf919eaf5a07b34e9b67bfa7b504"
+ARG dotfiles_commit="ef3c8ad5661ff184a63caca2172f2dc5e9ecd0e4"
 # Node.js のバージョンは次の URL を参照：
 #   https://nodejs.org/en/about/previous-releases
 ARG node_version="24.14.1"


### PR DESCRIPTION
## 概要
dotfiles を 1.1.16 に上げ、Claude Code CLI 用の MCP 設定の**置き場所だけ**を用意します（サーバー/認証＝中身はまだ）。

## 変更内容（`Dockerfile.dev.container`）
- `dotfiles_commit` を **1.1.16** の `ef3c8ad…` にピン更新（コメントも 1.1.15→1.1.16）
- **`container run` レシピは無変更**（中身が無いので認証・マウントは不要）

## dotfiles 1.1.16 側（別リポ・リリース済み）
- `config/mcp/`（`.gitkeep`＋`README`）を予約＋`install.sh` に条件付き symlink（`mcp.json` が**あれば** `~/.config/mcp/` に貼る）

## 検証（実機ビルド e2e）
- フルビルド成功（exit 0）。コンテナ内で **`~/.config/mcp/` が空フォルダとして存在・`mcp.json` 無し・リンク切れ無し**（`SLOT OK`）
- hadolint クリーン。旧ピン/旧タグ残存なし
- ※ ビルドログに出る `npm@lts` 失敗と `/claude-config` 権限警告は**既存かつ非致命**（node feature の挙動／ランタイム seed 前提）で、本変更とは無関係

🤖 Generated with [Claude Code](https://claude.com/claude-code)