### PR TITLE
chore(container): bump Debian base image to 12.14 (bookworm-20260623)

### DIFF
--- a/Dockerfile.dev.container
+++ b/Dockerfile.dev.container
@@ -126,8 +126,8 @@
 #   → 別ターミナルで:  curl http://localhost:3000
 #
 
-# Debian 12.13
-FROM docker.io/library/debian:bookworm-20260610
+# Debian 12.14
+FROM docker.io/library/debian:bookworm-20260623
 
 ARG user_name=developer
 ARG user_id


### PR DESCRIPTION
## 変更内容

`Dockerfile.dev.container` の base image をポイントリリース追従で更新:

- `# Debian 12.13` → `# Debian 12.14`
- `FROM docker.io/library/debian:bookworm-20260610` → `bookworm-20260623`

## 理由

Debian bookworm の新しい日付スナップショット（12.13 → 12.14）からビルドを開始し、ベースイメージ側の apt パッケージを最新化する。同一 bookworm 系列内のタグ更新のため破壊的変更はなし。

## 確認

- ローカルでフルビルドを実行し、新しい base image の pull と pin 済み apt バージョン（例: `openssh-server=1:9.2p1-2+deb12u10`）が解決することを検証。
- CI: ESLint (reviewdog) / hadolint / Security Scan。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
