### PR TITLE
chore(container): adopt dotfiles 1.1.17 (is-container fix; zsh history persists on Apple container)

### DIFF
--- a/Dockerfile.dev.container
+++ b/Dockerfile.dev.container
@@ -142,9 +142,9 @@ ARG features_commit="a8f0b45732c6b170aa48d9276c01da13be9d6e71"
 # https://github.com/uraitakahito/extra-utils/releases/tag/1.9.0
 ARG extra_utils_repository="https://github.com/uraitakahito/extra-utils.git"
 ARG extra_utils_commit="2706b43b67604fc8ccdb263ab6ff242ee66694b6"
-# https://github.com/uraitakahito/dotfiles/releases/tag/1.1.16
+# https://github.com/uraitakahito/dotfiles/releases/tag/1.1.17
 ARG dotfiles_repository="https://github.com/uraitakahito/dotfiles.git"
-ARG dotfiles_commit="ef3c8ad5661ff184a63caca2172f2dc5e9ecd0e4"
+ARG dotfiles_commit="b49076510e1b106597e38ae9cfc79bed6a26bd19"
 # Node.js のバージョンは次の URL を参照：
 #   https://nodejs.org/en/about/previous-releases
 ARG node_version="24.14.1"


### PR DESCRIPTION
## 変更内容

dotfiles のピンを **1.1.16 → 1.1.17**（`ef3c8ad` → `b490765`）へ更新。

## 背景（バグ）

Apple `container` で起動したコンテナを再起動すると zsh 履歴が消えていた。原因は dotfiles の `is-docker`（`[[ -e /.dockerenv ]]`）が **Docker 専用マーカーしか見ておらず**、Apple container（マーカー `/.cz-init`）を検出できず、`HISTFILE` の `/zsh-volume` 切替がスキップされて使い捨て FS に書かれていたため。

dotfiles 1.1.17 で `is-docker` → `is-container`（`/.dockerenv` / `/run/.containerenv` / `/.cz-init` / `$container` の OR）に置換して解決（[dotfiles#328](https://github.com/uraitakahito/dotfiles/pull/328)）。

## 検証（実機 E2E）

- フルビルド `BUILD_EXIT=0`
- 起動コンテナで `HISTFILE=/zsh-volume/.zsh_history`・`is-container=TRUE` を実測
- コンテナ1で履歴に目印を書込 → `stop`（`--rm` で FS 破棄）→ 同じ volume でコンテナ2を起動 → **目印が残存**（`fc -R` で history にロード）＝ **HISTORY_PERSISTS_OK**
- ホスト Mac は `is-container=false` のまま（挙動不変）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
