### PR TITLE
feat(dev): install graphify in both dev images

### DIFF
--- a/Dockerfile.dev.container
+++ b/Dockerfile.dev.container
@@ -141,7 +141,7 @@ ARG features_repository="https://github.com/devcontainers/features.git"
 ARG features_commit="a8f0b45732c6b170aa48d9276c01da13be9d6e71"
 # https://github.com/uraitakahito/extra-utils/releases/tag/1.9.0
 ARG extra_utils_repository="https://github.com/uraitakahito/extra-utils.git"
-ARG extra_utils_commit="2706b43b67604fc8ccdb263ab6ff242ee66694b6"
+ARG extra_utils_commit="de2552aed26d0961ccb202dd18724db846e2be4e"
 # https://github.com/uraitakahito/dotfiles/releases/tag/1.1.17
 ARG dotfiles_repository="https://github.com/uraitakahito/dotfiles.git"
 ARG dotfiles_commit="b49076510e1b106597e38ae9cfc79bed6a26bd19"
@@ -236,6 +236,10 @@ RUN cd /usr/src && \
     ADDIMAGEMAGICK=true \
     ADDNGINX=true \
     ADDUV=true \
+    # graphify は uv 経由で入るため ADDUV=true が前提です。
+    # スキル登録(graphify install)はイメージに含まれないので、
+    # コンテナ内で 1 度実行してください。
+    ADDGRAPHIFY=true \
     \
     ADDCLAUDECODE=true \
     # Claude Code は $HOME 配下にインストールされるため、ユーザー名の指定が必要。

--- a/Dockerfile.dev.docker
+++ b/Dockerfile.dev.docker
@@ -73,7 +73,7 @@ ARG features_repository="https://github.com/devcontainers/features.git"
 ARG features_commit="a8f0b45732c6b170aa48d9276c01da13be9d6e71"
 # https://github.com/uraitakahito/extra-utils/releases/tag/1.3.0
 ARG extra_utils_repository="https://github.com/uraitakahito/extra-utils.git"
-ARG extra_utils_commit="f975dbcb18f44b518cc181cedad57fd790d9894a"
+ARG extra_utils_commit="de2552aed26d0961ccb202dd18724db846e2be4e"
 # https://github.com/uraitakahito/dotfiles/releases/tag/1.1.12
 ARG dotfiles_repository="https://github.com/uraitakahito/dotfiles.git"
 ARG dotfiles_commit="c945f655428b97788b6b5c0071f425e0167cc05e"
@@ -144,6 +144,11 @@ RUN cd /usr/src && \
     ADDEZA=true \
     ADDGRPCURL=true \
     ADDHADOLINT=true \
+    ADDUV=true \
+    # graphify は uv 経由で入るため ADDUV=true が前提です。
+    # スキル登録(graphify install)はイメージに含まれないので、
+    # コンテナ内で 1 度実行してください。
+    ADDGRAPHIFY=true \
     \
     ADDCLAUDECODE=true \
     # Claude Code は $HOME 配下にインストールされるため、ユーザー名の指定が必要。


### PR DESCRIPTION
extra-utils gained an `ADDGRAPHIFY` opt-in
([uraitakahito/extra-utils#24](https://github.com/uraitakahito/extra-utils/pull/24));
both dev images now use it, and the pinned extra-utils commit moves to `de2552a`
to pick it up.

| image | before | after |
|---|---|---|
| `Dockerfile.dev.container` (Apple Container) | `ADDUV=true` | `+ ADDGRAPHIFY=true` |
| `Dockerfile.dev.docker` (Docker/OrbStack) | neither | `+ ADDUV=true`, `+ ADDGRAPHIFY=true` |

graphify is installed through `uv tool install`, which is why the two flags sit
adjacent with a comment rather than being sorted apart.

**Skill registration is not part of the image.** `graphify install` writes into
the user's home or the current repository, so it cannot usefully happen at build
time — the comment next to the flag says to run it once inside the container.

## Verification

Built `Dockerfile.dev.docker` with the documented command and checked **as the
image's own user** (`developer`, not root):

```
whoami              → developer
which graphify      → /usr/local/bin/graphify
graphify --version  → graphify 0.9.28
readlink -f         → /opt/uv-tools/graphifyy/bin/graphify

graphify install --project  → .claude/skills/graphify/SKILL.md
```

hadolint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Ekt6mAyoTEkxwaKc3tPUQ