### PR TITLE
chore(dev): extra-utils を 1.10.0 に更新

### DIFF
--- a/Dockerfile.dev.container
+++ b/Dockerfile.dev.container
@@ -139,9 +139,9 @@ ARG dev_user_commit="894e51b5cf42983af6c9e393ce93e163c365c9fe"
 # 本家の devcontainers/features
 ARG features_repository="https://github.com/devcontainers/features.git"
 ARG features_commit="a8f0b45732c6b170aa48d9276c01da13be9d6e71"
-# https://github.com/uraitakahito/extra-utils/releases/tag/1.9.0
+# https://github.com/uraitakahito/extra-utils/releases/tag/1.10.0
 ARG extra_utils_repository="https://github.com/uraitakahito/extra-utils.git"
-ARG extra_utils_commit="de2552aed26d0961ccb202dd18724db846e2be4e"
+ARG extra_utils_commit="7ab95b395752762b14317f5d28005e0208c2dd53"
 # https://github.com/uraitakahito/dotfiles/releases/tag/1.1.17
 ARG dotfiles_repository="https://github.com/uraitakahito/dotfiles.git"
 ARG dotfiles_commit="b49076510e1b106597e38ae9cfc79bed6a26bd19"

--- a/Dockerfile.dev.docker
+++ b/Dockerfile.dev.docker
@@ -71,9 +71,9 @@ ARG dev_user_commit="894e51b5cf42983af6c9e393ce93e163c365c9fe"
 # 本家の devcontainers/features
 ARG features_repository="https://github.com/devcontainers/features.git"
 ARG features_commit="a8f0b45732c6b170aa48d9276c01da13be9d6e71"
-# https://github.com/uraitakahito/extra-utils/releases/tag/1.3.0
+# https://github.com/uraitakahito/extra-utils/releases/tag/1.10.0
 ARG extra_utils_repository="https://github.com/uraitakahito/extra-utils.git"
-ARG extra_utils_commit="de2552aed26d0961ccb202dd18724db846e2be4e"
+ARG extra_utils_commit="7ab95b395752762b14317f5d28005e0208c2dd53"
 # https://github.com/uraitakahito/dotfiles/releases/tag/1.1.12
 ARG dotfiles_repository="https://github.com/uraitakahito/dotfiles.git"
 ARG dotfiles_commit="c945f655428b97788b6b5c0071f425e0167cc05e"


### PR DESCRIPTION
## 概要

両方の dev イメージが参照する `extra_utils_commit` を
[extra-utils 1.10.0](https://github.com/uraitakahito/extra-utils/releases/tag/1.10.0)
(`7ab95b3`) に更新しました。

## なぜ

pin していた `de2552a` の `install_graphify()` は `UV_TOOL_DIR` と
`UV_TOOL_BIN_DIR` しか指定していませんでした。1.10.0 では共通ヘルパ
`uv_tool_install()` に集約され、**`UV_PYTHON_INSTALL_DIR=/opt/uv-python`
も指定されます**。

uv が Python 本体を取得する場合、これが無いとインタプリタが `/root`(mode 700)
配下に置かれ、`developer` から実行すると
`bad interpreter: Permission denied` になります。現在の Debian ベースでは
`python3` が入っているため露見しないだけで、ベースを軽くすると壊れます。

## その他

- `Dockerfile.dev.docker` の pin コメントが `1.3.0` のまま取り残されていたので
  併せて修正しました（`Dockerfile.dev.container` は `1.9.0` でした）。
- extra-utils 側の変更は `install_cfn_lint()` の uv 化と README のみで、
  このリポジトリは `ADDCFNLINT` を使っていないため影響はありません。

## 動作確認

`Dockerfile.dev.docker` を実際にビルドして確認しました。

- `developer` ユーザで `graphify --version` → `graphify 0.9.28`
- `/usr/local/bin/graphify` → `/opt/uv-tools/graphifyy/bin/graphify`（world-readable）
- venv のインタプリタは `/opt/uv-tools/graphifyy/bin/python` → `/usr/bin/python3`
  で、`/root` 配下には依存していない。このベースには python3 があるため uv は
  Python を取得せず `/opt/uv-python` は作られない（＝上記の不具合が今は露見しない
  ことの裏付け）
- 併せて README の手順どおり `graphify install --project` をコンテナ内で実行し、
  フックに `/usr/local/bin/graphify hook-guard ...` が記録されることを確認

なお `npm install -g npm@lts` が ETARGET で失敗するログが出ますが、npm の
`lts` dist-tag が現存しないためで、この変更とは無関係です（feature 側が
リトライ後に続行し、ビルドは成功します）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Ekt6mAyoTEkxwaKc3tPUQ